### PR TITLE
Update: request to find template recursively

### DIFF
--- a/lua/telescope/_extensions/find_template.lua
+++ b/lua/telescope/_extensions/find_template.lua
@@ -7,11 +7,7 @@ local conf = require('telescope.config').values
 local temp_list = function()
   local temp = require('template')
   local file_ext = vim.fn.expand('%:e')
-  local temp_list = {}
-  local temp_abs_paths = vim.split(vim.fn.globpath(temp.temp_dir, '**/*.' .. file_ext), '\n') or {}
-  for _, temp_abs_path in pairs(temp_abs_paths) do
-    table.insert(temp_list, temp_abs_path:match('[^/]+$'))
-  end
+  local temp_list = vim.split(vim.fn.globpath(temp.temp_dir, '**/*.' .. file_ext), '\n') or {}
   return temp_list
 end
 

--- a/lua/telescope/_extensions/find_template.lua
+++ b/lua/telescope/_extensions/find_template.lua
@@ -6,7 +6,13 @@ local conf = require('telescope.config').values
 
 local temp_list = function()
   local temp = require('template')
-  return vim.split(vim.fn.globpath(temp.temp_dir, '*'), '\n')
+  local file_ext = vim.fn.expand('%:e')
+  local temp_list = {}
+  local temp_abs_paths = vim.split(vim.fn.globpath(temp.temp_dir, '**/*.' .. file_ext), '\n') or {}
+  for _, temp_abs_path in pairs(temp_abs_paths) do
+    table.insert(temp_list, temp_abs_path:match('[^/]+$'))
+  end
+  return temp_list
 end
 
 local find_template = function(opts)

--- a/lua/template/init.lua
+++ b/lua/template/init.lua
@@ -3,34 +3,16 @@ local uv, api, fn, fs = vim.loop, vim.api, vim.fn, vim.fs
 local sep = uv.os_uname().sysname == 'Windows_NT' and '\\' or '/'
 
 function temp.get_temp_list()
-  temp.temp_dir = fs.normalize(temp.temp_dir)
-  local all_temps = {}
-  local req = uv.fs_scandir(temp.temp_dir)
-  if not req then
-    vim.notify('[template.nvim] something wrong in get_temp_list callback')
-    return
-  end
-
-  local function iter()
-    return uv.fs_scandir_next(req)
-  end
-
-  for name, type in iter do
-    if type == 'file' then
-      table.insert(all_temps, name)
+  local temp_list = {}
+  local temp_abs_paths = vim.split(fn.globpath(temp.temp_dir, '/**/*.*'), '\n') or {}
+  for _, temp_abs_path in pairs(temp_abs_paths) do
+    local file_ext = temp_abs_path:match("[^.]+$")
+    if not temp_list[file_ext] then
+      temp_list[file_ext] = {}
     end
+    table.insert(temp_list[file_ext], temp_abs_path:match("[^/]+$"))
   end
-
-  local list = {}
-  for _, v in pairs(all_temps or {}) do
-    local ft = vim.filetype.match({ filename = v })
-    if ft then
-      list[ft] = {}
-      table.insert(list[ft], v)
-    end
-  end
-
-  return list
+  return temp_list
 end
 
 local expr = {

--- a/plugin/template.lua
+++ b/plugin/template.lua
@@ -12,6 +12,11 @@ end, {
   nargs = '+',
   complete = function(arg, line)
     local temp = require('template')
+    if not temp.temp_dir then
+      vim.notify('[template.nvim] please config the temp_dir variable')
+      return
+    end
+
     local cmd = vim.split(line, '%s+')
     table.remove(cmd, 1)
     local ft = vim.bo.filetype


### PR DESCRIPTION
The method for retrieving template files has been updated.
This allows users to organize their templates in the following directory structure.

/template
├── markdown
│   ├── temp1.md
│   ├── temp2.md
│   └── temp3.md
└── lua
    ├── temp1.lua
    ├── temp2.lua
    └── temp3.lua

Files are retrieved recurrently using file extensions, so they can be used in the same way as before.
Telescope's file search algorithm has been updated as well.