### PR TITLE
Fix whole line replacement when using lua

### DIFF
--- a/lua/template/init.lua
+++ b/lua/template/init.lua
@@ -72,7 +72,7 @@ local expand_expr = {
     return line:gsub(expr[7], file_name)
   end,
   [expr[8]] = function(line)
-    return line:match(expr[8]) and load('return ' .. line:match(expr[8]))() or line
+    return line:gsub(expr[8], load('return ' .. line:match(expr[8]))()) or line
   end,
 }
 


### PR DESCRIPTION
Fixed a problem where entire lines were replaced when using lua.

If the following template were used, it would look like this

```
{{_lua:hoge}} syntax error
before string: {{_lua:os.date("%Y-%m-%d")_}}
{{_lua:os.date("%Y-%m-%d")_}} : after string
```

## current version

```
{{_lua:hoge}} syntax error
2023-01-29
2023-01-29
```

## this PR

```
{{_lua:hoge}} syntax error
before string: 2023-01-29
2023-01-29 : after string
```
