### PR TITLE
Allow users to enable / disable filtetype based template filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Telescope find_template name=templatename
 
 -- when you select a template file it will insert this tempalte into current buffer
 Telecope find_template type=insert
+
+-- in both cases you can disable filtering templates by file type by passing `filter_ft=false`
+Telecope find_template type=insert filter_ft=false
 ```
 
 Then you can use `Telescope find_template` to check all templates

--- a/lua/telescope/_extensions/find_template.lua
+++ b/lua/telescope/_extensions/find_template.lua
@@ -6,13 +6,17 @@ local conf = require('telescope.config').values
 local actions = require('telescope.actions')
 local action_state = require('telescope.actions.state')
 
-local temp_list = function()
+local temp_list = function(opts)
   local temp = require('template')
   local list = vim.split(vim.fn.globpath(temp.temp_dir, '*'), '\n')
   local res = {}
   for _, fname in pairs(list or {}) do
-    local ft = vim.filetype.match({ filename = fname })
-    if ft and ft == vim.bo.filetype then
+    if opts.filter_ft then
+      local ft = vim.filetype.match({ filename = fname })
+      if ft and ft == vim.bo.filetype then
+        res[#res + 1] = fname
+      end
+    else
       res[#res + 1] = fname
     end
   end
@@ -35,7 +39,14 @@ local find_template = function(opts)
     end
   end
 
-  local results = temp_list()
+  -- by default is set for type=insert
+  -- unless is explicitly set by the filter_ft option which takes precedence
+  local filter_ft = (opts.type == 'insert')
+  if opts.filter_ft ~= nil then
+    filter_ft = opts.filter_ft
+  end
+
+  local results = temp_list({ filter_ft = filter_ft })
 
   local tbl = {
     prompt_title = 'find in templates',


### PR DESCRIPTION
This may be useful in few different scenarios:

1. Templates for Typescript files. Without modifying default Neovim config .ts file extension does not always point to a Typescript filetype: 
    ```lua
    -- TypeScript or Qt translation file (which is XML)
    ts = function(path, bufnr)
      return M.getlines(bufnr, 1):find('<%?xml') and 'xml' or 'typescript'
    end,
    ```
    Because of that, call to `vim.filetype.match()` file with only filename argument returns `nil` (event when `vim.bo.filetype` returns a proper type) and cannot be used to filter the templates: `vim.filetype.match({ filename = fname }) == vim.bo.filetype` returns false.

2. Sometimes you want to be able to insert templates / snippets of different type - for example in many frameworks you can embed markdown in comments to be later used for documentation generation - here using markdown based templates can be useful.

3. You are working with file markdown file, and you just want to insert a templated into a faced language block.

One thing to consider is if `name=<some_name>` should set `filter_ft=true` cause technically so far it worked like `type=insert` with extra step of file creation.

Let me know what you think.